### PR TITLE
Titles don't need to be uppercase

### DIFF
--- a/Husky.tex
+++ b/Husky.tex
@@ -57,7 +57,7 @@ To expand the capabilities of Husky, consider the following accessories offered 
 Each sensor package ships from Clearpath Robotics with a custom mounting bracket and cabling for easy attachment to Husky’s extruded aluminum payload mounting rail.
 
 
-\section{THE BASICS}
+\section{The Basics}
 
 This section provides an overview of the key specifications of the Husky platform. \autoref{husky_glance} gives a tour of key Husky components.
 
@@ -166,7 +166,7 @@ Key specifications of Husky are shown in \autoref{systemspecs} .
 	
 	\end{tabular}
 \newline
-\caption{Husky A200 System Specifications}
+\caption{Husky System Specifications}
 \label{systemspecs}
 \end{table}
 
@@ -184,7 +184,7 @@ $v=\frac{v_r+v_l}{2} , \omega=\frac{v_r-v_l}{w}  $
 v represents the instantaneous translational speed of the platform and ω the instantaneous rotational speed. $v_r$ and $v_l$ are 
 the right and left wheel velocities, respectively. w is the effective track of the vehicle, 0.555 m.
 
-\section{SAFETY}
+\section{Safety}
 Clearpath Robotics is committed to high standards of safety. Husky contains several features to protect the safety of users and the integrity of the vehicle.
 
 \subsection{General Warnings}
@@ -263,7 +263,7 @@ Monitoring these fields over longer periods of operation will allow you to ensur
 excessive wear on the motors.
 \newpage
 
-\section{GETTING STARTED}
+\section{Getting Started}
 
 You are ready to go! This section details how to get Husky into action.
 Before beginning, place Husky “up on blocks”, as described in the Safety section – make sure the wheels are clear of the ground.
@@ -409,7 +409,7 @@ Direct control using the Python or C++ interfaces is also possible, the API is a
 \url{http://www.clearpathrobotics.com/husky/downloads} However, please note that Clearpath Robotics no 
 longer provides support for these packages, and are supplied as is.
 
-\section{USING ROS}
+\section{Using ROS}
 Robot Operating System (ROS) is an extensible framework for controlling and working with robotic systems. 
 Clearpath Robotics recommends using ROS with Husky. If this is your first time using ROS, it is strongly 
 recommended to run through our series of ROS101 tutorials to learn the basics of ROS 
@@ -558,7 +558,7 @@ and dry with a towel.
 
 If water is suspected to have entered the Husky A200 chassis, remove the battery and allow Husky to fully dry for a minimum of 24 hours.
 
-\section{TIPS AND TROUBLESHOOTING}
+\section{Tips and Troubleshooting}
 
 \subsection{Mechanical Tips}
 Husky’s wheels can handle a range of different terrains, but work best when inflated to the proper pressure. 


### PR DESCRIPTION
The style rules take care of typesetting them properly, and this looks better in the ToC.
