### PR TITLE
Fix equation vars in body text.

### DIFF
--- a/Husky.tex
+++ b/Husky.tex
@@ -178,11 +178,11 @@ Key specifications of Husky are shown in \autoref{systemspecs} .
 As a starting point, Clearpath Robotics recommends using the following relationship between wheel velocity and platform velocity:
 \begin{figure}[h]
 \centering
-$v=\frac{v_r+v_l}{2} , \omega=\frac{v_r-v_l}{w}  $
+$v=\frac{v_r+v_l}{2} , \omega=\frac{v_r-v_l}{w}$
 \end{figure}
 
-v represents the instantaneous translational speed of the platform and ω the instantaneous rotational speed. $v_r$ and $v_l$ are 
-the right and left wheel velocities, respectively. w is the effective track of the vehicle, 0.555 m.
+$v$ represents the instantaneous translational speed of the platform and $w$ the instantaneous rotational speed. $v_r$ and $v_l$ are
+the right and left wheel velocities, respectively. $w$ is the effective track of the vehicle, 0.555 m.
 
 \section{SAFETY}
 Clearpath Robotics is committed to high standards of safety. Husky contains several features to protect the safety of users and the integrity of the vehicle.


### PR DESCRIPTION
Part of the fun of LaTeX is being able to embed equations and parts of equations (such as the symbols) right in the body text.
